### PR TITLE
Throw Unauthorized exception if the request returns a 401 status

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -19,6 +19,9 @@ class ResourceUnavailable(Exception):
 	def __str__(self):
 		return "Resource unavailable: %s" % (self._msg)
 
+class Unauthorized(ResourceUnavailable):
+	pass
+
 class TrelloClient(object):
 	""" Base class for Trello API access """
 
@@ -127,6 +130,8 @@ class TrelloClient(object):
 				body = json.dumps(post_args))
 
 		# error checking
+		if response.status == 401:
+			raise Unauthorized(url)
 		if response.status != 200:
 			raise ResourceUnavailable(url)
 		return json.loads(content)


### PR DESCRIPTION
I'm building a desktop app that integrates our internal bugtracking with Trello. I'm guiding the user through the OAuth process and store the oauth token locally, reusing it until it expires. In order to detect token expiration I'd like to see a different exception being raised so I can properly handle this case.
