### PR TITLE
fetch_actions() added to the Board class

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -265,6 +265,12 @@ class Board(object):
 			cards.append(card)
 
 		return cards
+		
+	def fetch_actions(self, action_filter):
+		json_obj = self.client.fetch_json(
+			'/boards/' + self.id + '/actions',
+			query_params = {'filter': action_filter})
+		self.actions = json_obj
 
 class List(object):
 	"""Class representing a Trello list. List attributes are stored on the object, but access to 


### PR DESCRIPTION
You can fetch the actions on an entire board, as well as just the lists or cards. (https://trello.com/docs/api/board/index.html#get-1-boards-board-id) This is useful if you want to snag all of a particular action on an entire board (rather then each card/list individually).
