### PR TITLE
Added info_for_all_boards()

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -42,7 +42,7 @@ class TrelloClient(object):
 
 		elif api_key:
 			self.client = Http()
-
+			
 		if token is None:
             		self.public_only = True
         	else:
@@ -61,7 +61,6 @@ class TrelloClient(object):
 					'/members/me/boards/all',
 					query_params = {'actions': actions})
 			self.all_info = json_obj
-
 
 	def logout(self):
 		"""Log out of Trello. This method is idempotent."""
@@ -126,11 +125,11 @@ class TrelloClient(object):
 			boards.append(self._board_from_json(obj))
 
 		return boards
-
+	
 	def get_board(self, board_id):
 		obj = self.fetch_json('/boards/' + board_id)
 		return self._board_from_json(obj)
-
+		
 	def add_board(self, board_name):
 		obj = self.fetch_json('/boards', http_method = 'POST', post_args = {'name':board_name})
 		board = Board(self, obj['id'], name=obj['name'].encode('utf-8'))
@@ -283,7 +282,7 @@ class Board(object):
 			cards.append(card)
 
 		return cards
-
+		
 	def fetch_actions(self, action_filter):
 		json_obj = self.client.fetch_json(
 			'/boards/' + self.id + '/actions',
@@ -344,7 +343,7 @@ class List(object):
 		card.url = json_obj['url']
 		card.member_ids = json_obj['idMembers']
 		return card
-
+		
 	def fetch_actions(self, action_filter):
 		"""
 		Fetch actions for this list can give more argv to action_filter, 
@@ -431,7 +430,7 @@ class Card(object):
 
 		:title: due a datetime object
 		"""
-
+		
 		datestr = due.strftime('%Y-%m-%d')
 		self._set_remote_attribute('due', datestr)
 		self.due = datestr
@@ -475,7 +474,7 @@ class Card(object):
 			post_args = args)
 
 	def add_checklist(self, title, items, itemstates=[]):
-
+		
 		"""Add a checklist to this card
 
 		:title: title of the checklist
@@ -487,7 +486,7 @@ class Card(object):
 				'/cards/'+self.id+'/checklists',
 				http_method = 'POST',
 				post_args = {'name': title},)
-
+		
 		cl = Checklist(self.client, [], json_obj, trello_card=self.id)
 		for i, name in enumerate(items):
 			try:
@@ -495,7 +494,7 @@ class Card(object):
 			except IndexError:
 				checked = False
 			cl.add_checklist_item(name, checked)
-
+		
 		self.fetch()
 		return cl
 
@@ -562,7 +561,7 @@ class Checklist(object):
 		json_obj['checked'] = checked
 		self.items.append(json_obj)
 		return json_obj
-
+		
 	def set_checklist_item(self, name, checked):		
 		"""Set the state of an item on this checklist
 
@@ -575,18 +574,18 @@ class Checklist(object):
 			[ix] = [i for i in range(len(self.items)) if self.items[i]['name'] == name]
 		except ValueError:
 			return
-
+		 
 		json_obj = self.client.fetch_json(
 				'/cards/'+self.trello_card+\
 				'/checklist/'+self.id+\
 				'/checkItem/'+self.items[ix]['id'],
 				http_method = 'PUT',
 				post_args = {'state': 'complete' if checked else 'incomplete'})
-
+		
 		json_obj['checked'] = checked
 		self.items[ix] = json_obj 
 		return json_obj
-
+	
 	def __repr__(self):
 		return '<Checklist %s>' % self.id
 


### PR DESCRIPTION
You can snag actions from all of a user's boards with one API call. If you want to get an aggregate of information from all of your boards, this is rather useful. Just pass in the `actions` you want to `TrelloClient.info_for_all_boards()`.

Thanks for the work on this wrapper, by the way, it's been really useful.
