### PR TITLE
Require a version of httplib2 that includes the DigiCert root certs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
 		'Operating System :: OS Independent',
 		'Programming Language :: Python',
 	],
-	install_requires = ['httplib2', 'oauth2',],
+	install_requires = ['httplib2 >= 0.9', 'oauth2',],
 	packages = find_packages(),
 	include_package_data = True,
 )


### PR DESCRIPTION
After they replaced their SSL certificates due to the HeartBleed issue,
the certificate for *.trello.com is signed by a chain that has the
DigiCert key at its root. Until version 0.9, httplib2 did not include
that cert in its cacerts.txt file.
