### PR TITLE
Rename header Content-type to Content-Type.

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -159,7 +159,7 @@ class TrelloClient(object):
         """ Fetch some JSON from Trello """
 
         if http_method in ("POST", "PUT", "DELETE"):
-            headers['Content-type'] = 'application/json'
+            headers['Content-Type'] = 'application/json'
 
         headers['Accept'] = 'application/json'
         url = self.build_url(uri_path, query_params)


### PR DESCRIPTION
oauth2 is pretty strict about the uppercase T and basically ruins
the request: It doesn't put the OAuth data in the request's headers
but replaces the body instead. Refs #42.
