### PR TITLE
Fix python2 support (no annotations)

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -476,7 +476,7 @@ class Card(object):
         return self.desc
 
     @property
-    def date_last_activity(self) -> datetime:
+    def date_last_activity(self):
         return self.dateLastActivity
 
     @description.setter


### PR DESCRIPTION
Python 2 doesn't support annotations, this patch removes the return value annotation on date_last_activity.
