### PR TITLE
Updated the create_oauth_token() function to include the ability to supp...

### DIFF
--- a/trello/util.py
+++ b/trello/util.py
@@ -4,7 +4,7 @@ import os
 
 from requests_oauthlib import OAuth1Session
 
-def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=None):
+def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=None, output=True):
     """
     Script to obtain an OAuth token from Trello.
 
@@ -33,10 +33,11 @@ def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=
     response = session.fetch_request_token(request_token_url)
     resource_owner_key, resource_owner_secret = response.get('oauth_token'), response.get('oauth_token_secret')
 
-    print("Request Token:")
-    print("    - oauth_token        = %s" % resource_owner_key)
-    print("    - oauth_token_secret = %s" % resource_owner_secret)
-    print("")
+    if output:
+        print("Request Token:")
+        print("    - oauth_token        = %s" % resource_owner_key)
+        print("    - oauth_token_secret = %s" % resource_owner_secret)
+        print("")
 
     # Step 2: Redirect to the provider. Since this is a CLI script we do not
     # redirect. In a web application you would redirect the user to the URL
@@ -76,12 +77,15 @@ def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=
                             verifier=oauth_verifier)
     access_token = session.fetch_access_token(access_token_url)
 
-    print("Access Token:")
-    print("    - oauth_token        = %s" % access_token['oauth_token'])
-    print("    - oauth_token_secret = %s" % access_token['oauth_token_secret'])
-    print("")
-    print("You may now access protected resources using the access tokens above.")
-    print("")
+    if output:
+        print("Access Token:")
+        print("    - oauth_token        = %s" % access_token['oauth_token'])
+        print("    - oauth_token_secret = %s" % access_token['oauth_token_secret'])
+        print("")
+        print("You may now access protected resources using the access tokens above.")
+        print("")
+
+    return access_token
 
 if __name__ == '__main__':
     create_oauth_token()


### PR DESCRIPTION
...ress printing the secrets and tokens, as well as returning the access tokens after the OAuth request.

Hey,

I'm interested in using this library in a little application I'm putting together. I noticed that you've done a lot of hard work to get the OAuth tokens, but it seems that the tokens aren't passed back programmatically. So I can call generate_oauth_token, but it doesn't appear to be accessible from outside the function after it's generated. Also, you're printing out the secrets and tokens without option. From a security standpoint, I think it should be optional whether the user's secrets are printed out but it can be used in a debugging situation, hence the addition of the option.

Let me know what you think, and thank you for the hard work!