### PR TITLE
Added due_date and pos attributes

### DIFF
--- a/test/test_trello.py
+++ b/test/test_trello.py
@@ -252,6 +252,21 @@ class TrelloBoardTestCase(unittest.TestCase):
         self.assertEquals(card.name, name)
         self.assertEquals(card.description, description)
 
+    def test55_set_pos(self):
+        card_names = lambda: [c.name for c in self._list.list_cards()]
+        self._list.add_card('card1')
+        card2 = self._list.add_card('card2')
+        names = card_names()
+        self.assertGreater(names.index('card2'), names.index('card1'))
+
+        card2.set_pos('top')
+        names = card_names()
+        self.assertGreater(names.index('card1'), names.index('card2'))
+
+        card2.set_pos('bottom')
+        names = card_names()
+        self.assertGreater(names.index('card2'), names.index('card1'))
+
     def test60_delete_cards(self):
         cards = self._board.get_cards()
         for card in cards:

--- a/test/test_trello.py
+++ b/test/test_trello.py
@@ -226,6 +226,8 @@ class TrelloBoardTestCase(unittest.TestCase):
         card.fetch()
         actual_due_date = card.due[:10]
         self.assertEquals(expected_due_date, actual_due_date)
+        # Note that set_due passes only the date, stripping time
+        self.assertEquals(card.due_date.date(), due_date.date())
 
     def test53_checklist(self):
         name = "Testing from Python"

--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -764,6 +764,10 @@ class Card(object):
         date_str = self.actions[0]['date'][:-5]
         return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
 
+    @property
+    def due_date(self):
+        return dateparser.parse(self.due)
+
     def set_name(self, new_name):
         """
         Update the name on the card to :new_name:

--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -670,6 +670,7 @@ class Card(object):
         self.idBoard = json_obj['idBoard']
         self.labels = json_obj['labels']
         self.badges = json_obj['badges']
+        self.pos = json_obj['pos']
         # For consistency, due date is in YYYY-MM-DD format
         if json_obj.get('due', ''):
             self.due = json_obj.get('due', '')[:10]
@@ -695,7 +696,7 @@ class Card(object):
                 '/cards/' + self.id + '/actions',
                 query_params={'filter': 'commentCard'})
         return comments
-    
+
     def fetch_checklists(self):
         checklists = []
         json_obj = self.client.fetch_json(
@@ -787,6 +788,15 @@ class Card(object):
         datestr = due.strftime('%Y-%m-%d')
         self._set_remote_attribute('due', datestr)
         self.due = datestr
+
+    def set_pos(self, pos):
+        """
+        Update card position in list
+
+        :pos: 'top', 'bottom' or int
+        """
+        self._set_remote_attribute('pos', pos)
+        self.pos = pos
 
     def set_closed(self, closed):
         self._set_remote_attribute('closed', closed)


### PR DESCRIPTION
I've added `due_date` property that returns a datetime object based on `due` string value, so it is consistent with other `Card's` `*_date` attributes. Also, added `pos` attribute with corresponding `set_pos` method (https://trello.com/docs/api/card/index.html#put-1-cards-card-id-or-shortlink-pos).