### PR TITLE
Card.board, Card Label return values.

### DIFF
--- a/test/test_trello.py
+++ b/test/test_trello.py
@@ -121,15 +121,13 @@ class TrelloBoardTestCase(unittest.TestCase):
             self._list = self._board.add_list('List')
 
     def _add_card(self, name, description=None):
-        try:
-            card = self._list.add_card(name, description)
-            self.assertIsNotNone(card, msg="card is None")
-            self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEquals(card.name, name)
-            return card
-        except Exception as e:
-            print(str(e))
-            self.fail("Caught Exception adding card")
+        card = self._list.add_card(name, description)
+        self.assertIsNotNone(card, msg="card is None")
+        self.assertIsNotNone(card.id, msg="id not provided")
+        self.assertEquals(card.name, name)
+        self.assertEqual(card.board, self._board)
+        self.assertEqual(card.trello_list, self._list)
+        return card
 
     def test40_add_card(self):
         name = "Testing from Python - no desc"
@@ -206,6 +204,8 @@ class TrelloBoardTestCase(unittest.TestCase):
                 self.assertEqual(card.description, '')
             else:
                 self.fail(msg='Unexpected card found')
+
+            self.assertFalse(hasattr(card, 'trello_list'))
 
         self.assertIsInstance(self._board.all_cards(), list)
         self.assertIsInstance(self._board.open_cards(), list)

--- a/test/test_trello.py
+++ b/test/test_trello.py
@@ -108,17 +108,18 @@ class TrelloBoardTestCase(unittest.TestCase):
     independently.
     """
 
-    def setUp(self):
-        self._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
-                                    token=os.environ['TRELLO_TOKEN'])
-        for b in self._trello.list_boards():
+    @classmethod
+    def setUpClass(cls):
+        cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
+                                   token=os.environ['TRELLO_TOKEN'])
+        for b in cls._trello.list_boards():
             if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
-                self._board = b
+                cls._board = b
                 break
         try:
-            self._list = self._board.open_lists()[0]
+            cls._list = cls._board.open_lists()[0]
         except IndexError:
-            self._list = self._board.add_list('List')
+            cls._list = cls._board.add_list('List')
 
     def _add_card(self, name, description=None):
         card = self._list.add_card(name, description)

--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -382,7 +382,7 @@ class Board(object):
         json_obj = self.client.fetch_json(
               '/boards/' + self.id + '/labels',
               query_params={'fields': fields, 'limit': limit})
-        return [Label.from_json(board=self, json_obj=obj) for obj in json_obj]
+        return Label.from_json_list(self, json_obj)
 
     def add_list(self, name):
         """Add a list to this board
@@ -407,7 +407,7 @@ class Board(object):
         obj = self.client.fetch_json(
             '/labels',
             http_method='POST',
-            post_args={'name':name, 'idBoard': self.id, 'color': color},)
+            post_args={'name': name, 'idBoard': self.id, 'color': color},)
         return Label.from_json(board=self, json_obj=obj)
 
     def all_cards(self):
@@ -696,7 +696,7 @@ class Card(object):
         card.url = json_obj['url']
         card.member_ids = json_obj['idMembers']
         card.idLabels = json_obj['idLabels']
-        card.labels = json_obj['labels']
+        card.labels = Label.from_json_list(card.board, json_obj['labels'])
         return card
 
     def __repr__(self):
@@ -720,7 +720,7 @@ class Card(object):
         self.idList = json_obj['idList']
         self.idBoard = json_obj['idBoard']
         self.idLabels = json_obj['idLabels']
-        self.labels = json_obj['labels']
+        self.labels = Label.from_json_list(self.board, json_obj['labels'])
         self.badges = json_obj['badges']
         self.pos = json_obj['pos']
         # For consistency, due date is in YYYY-MM-DD format
@@ -979,6 +979,10 @@ class Label(object):
         """
         label = Label(board.client, label_id=json_obj['id'], name=json_obj['name'].encode('utf-8'), color=json_obj['color'])
         return label
+
+    @classmethod
+    def from_json_list(cls, board, json_objs):
+        return [cls.from_json(board, obj) for obj in json_objs]
 
     def __repr__(self):
         return '<Label %s>' % self.name

--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -663,18 +663,23 @@ class Card(object):
             self._checklists = self.fetch_checklists()
         return self._checklists
 
-    def __init__(self, trello_list, card_id, name=''):
+    def __init__(self, parent, card_id, name=''):
         """
         :trello_list: reference to the parent list
         :card_id: ID for this card
         """
-        self.trello_list = trello_list
-        self.client = trello_list.client
+        if isinstance(parent, List):
+            self.trello_list = parent
+            self.board = parent.board
+        else:
+            self.board = parent
+
+        self.client = parent.client
         self.id = card_id
         self.name = name
 
     @classmethod
-    def from_json(cls, trello_list, json_obj):
+    def from_json(cls, parent, json_obj):
         """
         Deserialize the card json object to a Card object
 
@@ -683,7 +688,7 @@ class Card(object):
         """
         if 'id' not in json_obj:
             raise Exception("key 'id' is not in json_obj")
-        card = cls(trello_list,
+        card = cls(parent,
                    json_obj['id'],
                    name=json_obj['name'].encode('utf-8'))
         card.desc = json_obj.get('desc', '')


### PR DESCRIPTION
Summary of changes:

- Cards are initialized with either board or a list as a parent. It was utilized in this way before (see `Board.get_cards()`) , but board ended up being stored in `self.trello_list`. `Card.board` is added and available in either case while `self.trello_list` is not.
- `Card.get_labels` and `Card.labels` return `Label` classes instead of dictionaries. This is consistent with `Board.get_labels`.
- `setUp()` changed to `setUpClass` for slight speedup (10 seconds on my machine)
