### PR TITLE
Bit of straightening out about the environment variables.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,11 +54,13 @@ Found in requirements.txt
 
 Tests
 =====
-To run the tests, run `python tests.py`. Three environment variables must be set:
+To run the tests, run `python tests.py`. Two additional environment variables must be set:
 
-* TRELLO_API_KEY: your Trello API key  
-* TRELLO_TOKEN: your Trello OAuth token  
-* TRELLO_TEST_BOARD_COUNT: the number of boards in your Trello account  
+* TRELLO_TOKEN: the Trello OAuth token for the user whose boards you will access
+* TRELLO_TEST_BOARD_COUNT: the number of boards in your Trello account 
+
+One environment variable is optional:
+
 * TRELLO_TEST_BOARD_NAME: name of the board to test card manipulation on. Must be unique, or the first match will be used
 
 And run (from `py-trello/`):


### PR DESCRIPTION
Trying to make this a bit more clear for someone first using it.

It would also be easier if there was a way to set the ivar values via the command line or in a resource file. As it is now, I get:

$ python ./trello/util.py
Traceback (most recent call last):
  File "./trello/util.py", line 91, in <module>
    create_oauth_token()
  File "./trello/util.py", line 24, in create_oauth_token
    trello_key = key or os.environ['TRELLO_API_KEY']
  File "/usr/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TRELLO_API_KEY'
$ 
$ echo $TRELLO_API_KEY
2b6790f8042489d77227f3a632ae0add
$ 

So, the environment variable is set, but not in the right way?

FYI, I am on an Ubuntu 14.04 system.

Also, your TrelloClient requires a:
* api_key='your-key'
* api_secret='your-secret'
* token='your-oauth-token-key'
* token_secret='your-oauth-token-secret'

I can see what the first three are. What is a token_secret? I get the OAuth token and ... that is it.

