### PR TITLE
Remove unused Member.commentCard attribute

### DIFF
--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -1108,7 +1108,6 @@ class Member(object):
         self.username = json_obj['username']
         self.full_name = json_obj['fullName']
         self.initials = json_obj['initials']
-        self.commentCard = json_obj['commentCard']
         return self
 
     def fetch_comments(self):


### PR DESCRIPTION
Fixes sarumont/py-trello#80

commit 3ad3915 introduce a commentCard attribute to the Member class
which appears to be unused.

  File "trello/__init__.py", line 141, in get_member
    return Member(self, member_id).fetch()
  File "trello/__init__.py", line 1113, in fetch
    self.commentCard = json_obj['commentCard']
  KeyError: 'commentCard'