### PR TITLE
Changed datetime.strptime to dateparser.parse to parse properly RFC 3339 datetime strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 requests-oauthlib
+python-dateutil

--- a/trello/__init__.py
+++ b/trello/__init__.py
@@ -875,8 +875,8 @@ class Card(object):
         self.fetch_actions('updateCard:idList')
         res =[]
         for idx in self.actions:
-            date_str = idx['date'][:-5]
-            dateDate = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
+            date_str = idx['date']
+            dateDate = dateparser.parse(date_str)
             strLst = idx['data']['listBefore']['name']
             endLst = idx['data']['listAfter']['name']
             res.append([strLst,endLst,dateDate])
@@ -889,8 +889,8 @@ class Card(object):
 
         """
         self.fetch_actions('updateCard:idList')
-        date_str = self.actions[0]['date'][:-5]
-        return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
+        date_str = self.actions[0]['date']
+        return dateparser.parse(date_str)
 
     @property
     def create_date(self):
@@ -901,8 +901,8 @@ class Card(object):
                 test for the condition.
         """
         self.fetch_actions()
-        date_str = self.actions[0]['date'][:-5]
-        return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
+        date_str = self.actions[0]['date']
+        return dateparser.parse(date_str)
 
     @property
     def due_date(self):


### PR DESCRIPTION
Changed to parse properly RFC 3339 datetime strings (the format used in Trello API)
https://stackoverflow.com/questions/127803/how-to-parse-iso-formatted-date-in-python