### PR TITLE
Add card filter parameter to List.list_cards()

### DIFF
--- a/trello/trellolist.py
+++ b/trello/trellolist.py
@@ -40,9 +40,9 @@ class List(object):
         self.name = json_obj['name']
         self.closed = json_obj['closed']
 
-    def list_cards(self):
+    def list_cards(self, card_filter="open"):
         """Lists all cards in this list"""
-        json_obj = self.client.fetch_json('/lists/' + self.id + '/cards')
+        json_obj = self.client.fetch_json('/lists/' + self.id + '/cards/' + card_filter)
         return [Card.from_json(self, c) for c in json_obj]
 
     def add_card(self, name, desc=None, labels=[], due="null"):


### PR DESCRIPTION
This doesn't appear documented anywhere by Trello, but [`GET /1/lists/[idList]/cards`](https://developers.trello.com/advanced-reference/list#get-1-lists-idlist-cards) only returns open cards.

My pull request makes that explicit, and by using a different endpoint, [`GET /1/lists/[idList]/cards/[filter]`](https://developers.trello.com/advanced-reference/list#get-1-lists-idlist-cards-filter), it allows querying for `all`, `open`, `closed`, or `none` cards in a list.

Thanks for all your work on this project.