### PR TITLE
Implement more checklist operations

### DIFF
--- a/test/test_checklist.py
+++ b/test/test_checklist.py
@@ -83,8 +83,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
 
     def test_delete_checklist_item(self):
         name = "Testing checklist item delete"
-        description = "Description goes here"
-        card = self._list.add_card(name, description)
+        card = self._list.add_card(name, "Description goes here")
 
         name = 'Checklist'
         checklist = self._add_checklist(card, name, ['item1', 'item2'])
@@ -94,7 +93,16 @@ class TrelloChecklistTestCase(unittest.TestCase):
         self.assertEqual(len(checklists[0].items), 1)
         self.assertEqual(checklists[0].items[0]['name'], 'item1')
 
-        card.delete()
+    def test_clear_checklist(self):
+        name = "Testing checklist clear"
+        card = self._list.add_card(name, "Description goes here")
+
+        name = 'Checklist'
+        checklist = self._add_checklist(card, name, ['item1', 'item2', 'item3'])
+        checklist.clear()
+
+        checklists = card.fetch_checklists()
+        self.assertEqual(len(checklists[0].items), 0)
 
 
 def suite():

--- a/test/test_checklist.py
+++ b/test/test_checklist.py
@@ -81,6 +81,21 @@ class TrelloChecklistTestCase(unittest.TestCase):
         self.assertEqual(len(card.checklists), 1)
         self.assertEqual(card.checklists[0].name, new_name)
 
+    def test_delete_checklist_item(self):
+        name = "Testing checklist item delete"
+        description = "Description goes here"
+        card = self._list.add_card(name, description)
+
+        name = 'Checklist'
+        checklist = self._add_checklist(card, name, ['item1', 'item2'])
+        checklist.delete_checklist_item('item2')
+
+        checklists = card.fetch_checklists()
+        self.assertEqual(len(checklists[0].items), 1)
+        self.assertEqual(checklists[0].items[0]['name'], 'item1')
+
+        card.delete()
+
 
 def suite():
     # tests = ['test01_list_boards', 'test10_board_attrs', 'test20_add_card']

--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -34,6 +34,22 @@ class Checklist(object):
         self.items.append(json_obj)
         return json_obj
 
+    def delete_checklist_item(self, name):
+        """Delete an item on this checklist
+
+        :name: name of the checklist item to delete
+        """
+        ix = self._get_item_id(name)
+        if ix is None:
+            return
+
+        obj = self.client.fetch_json(
+            '/checklists/'+ self.id +
+            '/checkItems/'+ self.items[ix]['id'],
+            http_method='DELETE')
+        del self.items[ix]
+
+
     def set_checklist_item(self, name, checked):
         """Set the state of an item on this checklist
 
@@ -102,6 +118,15 @@ class Checklist(object):
         self.client.fetch_json(
             '/checklists/%s' % self.id,
             http_method='DELETE')
+
+    def _get_item_id(self, name):
+        """Locate the id of the checklist item"""
+        try:
+            [ix] = [i for i in range(len(self.items)) if
+                    self.items[i]['name'] == name]
+            return ix
+        except ValueError:
+            return None
 
     def __repr__(self):
         return '<Checklist %s>' % self.id

--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -43,12 +43,18 @@ class Checklist(object):
         if ix is None:
             return
 
-        obj = self.client.fetch_json(
+        self.client.fetch_json(
             '/checklists/'+ self.id +
             '/checkItems/'+ self.items[ix]['id'],
             http_method='DELETE')
         del self.items[ix]
 
+    def clear(self):
+        """Clear checklist by removing all checklist items"""
+        # iterate over names as list is modified while iterating and this breaks
+        # for-loops behaviour
+        for name in [item['name'] for item in self.items]:
+            self.delete_checklist_item(name)
 
     def set_checklist_item(self, name, checked):
         """Set the state of an item on this checklist

--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -56,12 +56,8 @@ class Checklist(object):
         :name: name of the checklist item
         :checked: True if item state should be checked, False otherwise
         """
-
-        # Locate the id of the checklist item
-        try:
-            [ix] = [i for i in range(len(self.items)) if
-                    self.items[i]['name'] == name]
-        except ValueError:
+        ix = self._get_item_id(name)
+        if ix is None:
             return
 
         json_obj = self.client.fetch_json(
@@ -96,11 +92,8 @@ class Checklist(object):
         :name: name of the checklist item
         :new_name: new name of item
         """
-
-        # Locate the id of the checklist item
-        try:
-            [ix] = [i for i in range(len(self.items)) if self.items[i]['name'] == name]
-        except ValueError:
+        ix = self._get_item_id(name)
+        if ix is None:
             return
 
         json_obj = self.client.fetch_json(


### PR DESCRIPTION
I implemented deleting of single checklist items and also clearing of lists. 

Motivation for the latter was mainly, because if you recreate checklists by deleting and adding them again, and you do that automatically you may end up with a lot of noise in the card's activity/action stream.