### PR TITLE
Unicode handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,19 +10,23 @@ for feature requests, discussion and some development tracking.
 Install
 =======
 
-    pip install py-trello
+```
+pip install py-trello
+```
 
 Usage
 =====
 
-    from trello import TrelloClient
+```python
+from trello import TrelloClient
 
-    client = TrelloClient(
-        api_key='your-key',
-        api_secret='your-secret',
-        token='your-oauth-token-key',
-        token_secret='your-oauth-token-secret'
-    )
+client = TrelloClient(
+    api_key='your-key',
+    api_secret='your-secret',
+    token='your-oauth-token-key',
+    token_secret='your-oauth-token-secret'
+)
+```
 
 Where `token` and `token_secret` come from the 3-legged OAuth process and
 `api_key` and `api_secret` are your Trello API credentials that are
@@ -47,20 +51,23 @@ https://trello.com/docs/gettingstarted/#getting-a-token-from-a-user
 
 Run
 
-    python ./trello/util.py
+```
+python ./trello/util.py
+```
 
 Required Python modules
 =======================
-Found in requirements.txt
+
+Found in `requirements.txt`
 
 Tests
 =====
 To run the tests, run `python -m unittest discover`. Four environment variables must be set:
 
-* TRELLO_API_KEY: your Trello API key
-* TRELLO_TOKEN: your Trello OAuth token
-* TRELLO_TEST_BOARD_COUNT: the number of boards in your Trello account
-* TRELLO_TEST_BOARD_NAME: name of the board to test card manipulation on. Must be unique, or the first match will be used
+* `TRELLO_API_KEY`: your Trello API key
+* `TRELLO_TOKEN`: your Trello OAuth token
+* `TRELLO_TEST_BOARD_COUNT`: the number of boards in your Trello account
+* `TRELLO_TEST_BOARD_NAME`: name of the board to test card manipulation on. Must be unique, or the first match will be used
 
 To run tests across various Python versions,
 [tox](https://tox.readthedocs.io/en/latest/) is supported. Install it

--- a/README.rst
+++ b/README.rst
@@ -55,16 +55,16 @@ Found in requirements.txt
 
 Tests
 =====
-To run the tests, run `python tests.py`. Three environment variables must be set:
+To run the tests, run `python -m unittest discover`. Four environment variables must be set:
 
 * TRELLO_API_KEY: your Trello API key
 * TRELLO_TOKEN: your Trello OAuth token
 * TRELLO_TEST_BOARD_COUNT: the number of boards in your Trello account
 * TRELLO_TEST_BOARD_NAME: name of the board to test card manipulation on. Must be unique, or the first match will be used
 
-And run (from `py-trello/`):
-
-    PYTHONPATH=. python test/test_trello.py
+To run tests across various Python versions,
+[tox](https://tox.readthedocs.io/en/latest/) is supported. Install it
+and simply run `tox` from the `py-trello` directory.
 
 Contributors
 ============

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -18,7 +18,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:
@@ -30,7 +30,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEqual(card.name, name.encode('utf-8'))
+            self.assertEqual(card.name, name)
             return card
         except Exception as e:
             print(str(e))
@@ -57,7 +57,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         self.assertEquals(len(cards), len(self._board.open_cards()))
 
         for card in cards:
-            self.assertTrue(card.name.decode('utf-8') in names, 'Unexpected card found')
+            self.assertTrue(card.name in names, 'Unexpected card found')
 
         self.assertIsInstance(self._board.all_cards(), list)
         self.assertIsInstance(self._board.open_cards(), list)
@@ -145,27 +145,27 @@ class TrelloBoardTestCase(unittest.TestCase):
         test_list = test_board.add_list("test_list")
         test_list.add_card("test_card")
         open_boards = self._trello.list_boards(board_filter="open")
-        self.assertEqual(len([x for x in open_boards if x.name == "test_create_board".encode('utf-8')]), 1)
+        self.assertEqual(len([x for x in open_boards if x.name == "test_create_board"]), 1)
 
     def test110_copy_board(self):
         boards = self._trello.list_boards(board_filter="open")
-        source_board = next( x for x in boards if x.name == "test_create_board".encode('utf-8'))
+        source_board = next( x for x in boards if x.name == "test_create_board")
         self._trello.add_board("copied_board", source_board=source_board)
         listed_boards = self._trello.list_boards(board_filter="open")
-        copied_board = next(iter([x for x in listed_boards if x.name == "copied_board".encode('utf-8')]), None)
+        copied_board = next(iter([x for x in listed_boards if x.name == "copied_board"]), None)
         self.assertIsNotNone(copied_board)
         open_lists = copied_board.open_lists()
         self.assertEqual(len(open_lists), 4) # default lists plus mine
         test_list = open_lists[0]
         self.assertEqual(len(test_list.list_cards()), 1)
-        test_card = next ( iter([ x for x in test_list.list_cards() if x.name == "test_card".encode('utf-8')]), None )
+        test_card = next ( iter([ x for x in test_list.list_cards() if x.name == "test_card"]), None )
         self.assertIsNotNone(test_card)
 
     def test120_close_board(self):
         boards = self._trello.list_boards(board_filter="open")
         open_count = len(boards)
-        test_create_board = next( x for x in boards if x.name == "test_create_board".encode('utf-8')) # type: Board
-        copied_board = next( x for x in boards if x.name == "copied_board".encode('utf-8')) # type: Board
+        test_create_board = next( x for x in boards if x.name == "test_create_board") # type: Board
+        copied_board = next( x for x in boards if x.name == "copied_board") # type: Board
         test_create_board.close()
         copied_board.close()
         still_open_boards = self._trello.list_boards(board_filter="open")

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -40,7 +40,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         checklist = card.add_checklist(name, items, itemstates)
         self.assertIsNotNone(checklist, msg="checklist is None")
         self.assertIsNotNone(checklist.id, msg="id not provided")
-        self.assertEquals(checklist.name, name)
+        self.assertEqual(checklist.name, name)
         return checklist
 
     def test_get_cards(self):
@@ -53,8 +53,8 @@ class TrelloBoardTestCase(unittest.TestCase):
         for i in range(nb_cards):
             self._add_card(names[i])
         cards = self._board.get_cards()
-        self.assertEquals(len(cards), nb_cards)
-        self.assertEquals(len(cards), len(self._board.open_cards()))
+        self.assertEqual(len(cards), nb_cards)
+        self.assertEqual(len(cards), len(self._board.open_cards()))
 
         for card in cards:
             self.assertTrue(card.name in names, 'Unexpected card found')
@@ -88,7 +88,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         for card in cards:
             card.delete()
         self._board.fetch_actions(action_filter='all', action_limit=nb_open_cards)
-        self.assertEquals(len(self._board.actions), nb_open_cards)
+        self.assertEqual(len(self._board.actions), nb_open_cards)
         for action in self._board.actions:
             self.assertEqual(action['type'], 'deleteCard')
 
@@ -101,7 +101,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card.set_closed(True)
         cards_after = self._board.closed_cards()
         nb_cards_after = len(cards_after)
-        self.assertEquals(nb_cards_after, nb_closed_cards + nb_open_cards)
+        self.assertEqual(nb_cards_after, nb_closed_cards + nb_open_cards)
 
 
     def test_all_cards_reachable(self):

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -30,7 +30,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEquals(card.name, name)
+            self.assertEqual(card.name, name)
             return card
         except Exception as e:
             print(str(e))
@@ -44,7 +44,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         self.assertFalse(card.closed, msg="Card should not be closed")
 
         card2 = self._trello.get_card(card.id)
-        self.assertEquals(card.name, card2.name)
+        self.assertEqual(card.name, card2.name)
 
     def test41_add_card_desc(self):
         name = "Testing from Python"
@@ -52,7 +52,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         card = self._add_card(name, description)
 
         card.fetch()
-        self.assertEquals(description, card.description)
+        self.assertEqual(description, card.description)
         self.assertIsNotNone(card.url, msg="url not provided")
         self.assertIsNotNone(card.member_id)
         self.assertIsNotNone(card.short_id)
@@ -68,8 +68,8 @@ class TrelloBoardTestCase(unittest.TestCase):
         card.comment(comment)
         card.fetch(True)
 
-        self.assertEquals(len(card.comments), 1)
-        self.assertEquals(card.comments[0]['data']['text'], comment)
+        self.assertEqual(len(card.comments), 1)
+        self.assertEqual(card.comments[0]['data']['text'], comment)
 
     def test43_get_comments(self):
         name = "Card with comments 2"
@@ -77,8 +77,8 @@ class TrelloBoardTestCase(unittest.TestCase):
         card = self._add_card(name)
         card.comment(comment)
         card._comments = card.get_comments()
-        self.assertEquals(len(card.comments), 1)
-        self.assertEquals(card.comments[0]['data']['text'], comment)
+        self.assertEqual(len(card.comments), 1)
+        self.assertEqual(card.comments[0]['data']['text'], comment)
 
     def test44_attach_url_to_card(self):
         name = "Testing from Python - url"
@@ -86,7 +86,7 @@ class TrelloBoardTestCase(unittest.TestCase):
 
         card.attach(name='lwn', url='http://lwn.net/')
         card.fetch()
-        self.assertEquals(card.badges['attachments'], 1)
+        self.assertEqual(card.badges['attachments'], 1)
         card.delete()
 
     def test52_add_card_set_due(self):
@@ -102,21 +102,21 @@ class TrelloBoardTestCase(unittest.TestCase):
         # Refresh the due date from cloud
         card.fetch()
         actual_due_date = card.due
-        self.assertEquals(expected_due_date[:8], actual_due_date[:8])
+        self.assertEqual(expected_due_date[:8], actual_due_date[:8])
 
     def test_set_name(self):
         name = "Testing set card name"
         card = self._list.add_card('noname')
         card.set_name(name)
-        self.assertEquals(card.name, name)
+        self.assertEqual(card.name, name)
 
     def test_set_desc(self):
         card = self._list.add_card("Testing set card desc")
         description = "Description goes here"
         card.set_description(description)
-        self.assertEquals(card.description, description)
+        self.assertEqual(card.description, description)
         card.fetch()
-        self.assertEquals(card.description, description)
+        self.assertEqual(card.description, description)
 
     def test_set_closed(self):
         name = "Testing set card closed"

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -18,7 +18,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:
@@ -30,7 +30,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEquals(card.name, name.encode('utf-8'))
+            self.assertEquals(card.name, name)
             return card
         except Exception as e:
             print(str(e))

--- a/test/test_checklist.py
+++ b/test/test_checklist.py
@@ -30,7 +30,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEquals(card.name, name)
+            self.assertEqual(card.name, name)
             return card
         except Exception as e:
             print(str(e))
@@ -40,7 +40,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
         checklist = card.add_checklist(name, items)
         self.assertIsNotNone(checklist, msg="checklist is None")
         self.assertIsNotNone(checklist.id, msg="id not provided")
-        self.assertEquals(checklist.name, name)
+        self.assertEqual(checklist.name, name)
         return checklist
 
     def test_delete_checklist(self):
@@ -76,7 +76,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
         new_name = "Renamed"
         checklist = self._add_checklist(card, name, ['item1', 'item2'])
         checklist.rename(new_name)
-        self.assertEquals(checklist.name, new_name)
+        self.assertEqual(checklist.name, new_name)
         card._checklists = card.fetch_checklists()
         self.assertEqual(len(card.checklists), 1)
         self.assertEqual(card.checklists[0].name, new_name)

--- a/test/test_checklist.py
+++ b/test/test_checklist.py
@@ -18,7 +18,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:

--- a/test/test_trello_client.py
+++ b/test/test_trello_client.py
@@ -20,7 +20,7 @@ class TrelloClientTestCase(unittest.TestCase):
                                     token=os.environ['TRELLO_TOKEN'])
 
     def test01_list_boards(self):
-        self.assertEquals(
+        self.assertEqual(
             len(self._trello.list_boards(board_filter="open")),
             int(os.environ['TRELLO_TEST_BOARD_COUNT']))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+	py27,
+	py34,
+	py35
+
+[testenv]
+passenv = TRELLO_*
+setenv =
+	PYTHONPATH={toxinidir}
+commands =
+	python -m unittest discover
+deps =
+	requests
+	requests-oauthlib>=0.4.1
+	python-dateutil

--- a/trello/board.py
+++ b/trello/board.py
@@ -2,6 +2,7 @@
 from __future__ import with_statement, print_function, absolute_import
 from trello.member import Member
 from trello.card import Card
+from trello.compat import force_str
 from trello.trellolist import List
 from trello.label import Label
 from trello.checklist import Checklist
@@ -52,11 +53,11 @@ class Board(object):
         :json_obj: the json board object
         """
         if organization is None:
-            board = Board(client=trello_client, board_id=json_obj['id'], name=json_obj['name'].encode('utf-8'))
+            board = Board(client=trello_client, board_id=json_obj['id'], name=json_obj['name'])
         else:
-            board = Board(organization=organization, board_id=json_obj['id'], name=json_obj['name'].encode('utf-8'))
+            board = Board(organization=organization, board_id=json_obj['id'], name=json_obj['name'])
 
-        board.description = json_obj.get('desc', '').encode('utf-8')
+        board.description = json_obj.get('desc', '')
         board.closed = json_obj['closed']
         board.url = json_obj['url']
 
@@ -68,7 +69,7 @@ class Board(object):
         return board
 
     def __repr__(self):
-        return '<Board %s>' % self.name
+        return force_str(u'<Board %s>' % self.name)
 
     def fetch(self):
         """Fetch all attributes for this board"""
@@ -293,13 +294,13 @@ class Board(object):
         members = list()
         for obj in json_obj:
             m = Member(self.client, obj['id'])
-            m.status = obj.get('status', '').encode('utf-8')
+            m.status = obj.get('status', '')
             m.id = obj.get('id', '')
             m.bio = obj.get('bio', '')
             m.url = obj.get('url', '')
-            m.username = obj['username'].encode('utf-8')
-            m.full_name = obj['fullName'].encode('utf-8')
-            m.initials = obj.get('initials', '').encode('utf-8')
+            m.username = obj['username']
+            m.full_name = obj['fullName']
+            m.initials = obj.get('initials', '')
             members.append(m)
 
         return members

--- a/trello/card.py
+++ b/trello/card.py
@@ -2,6 +2,7 @@
 from __future__ import with_statement, print_function, absolute_import
 from dateutil import parser as dateparser
 from datetime import datetime
+from trello.compat import force_str
 from trello.checklist import Checklist
 from trello.label import Label
 
@@ -123,7 +124,7 @@ class Card(object):
             raise Exception("key 'id' is not in json_obj")
         card = cls(parent,
                    json_obj['id'],
-                   name=json_obj['name'].encode('utf-8'))
+                   name=json_obj['name'])
         card.desc = json_obj.get('desc', '')
         card.due = json_obj.get('due', '')
         card.closed = json_obj['closed']
@@ -136,7 +137,7 @@ class Card(object):
         return card
 
     def __repr__(self):
-        return '<Card %s>' % self.name
+        return force_str(u'<Card %s>' % self.name)
 
     def fetch(self, eager=True):
         """
@@ -147,7 +148,7 @@ class Card(object):
             '/cards/' + self.id,
             query_params={'badges': False})
         self.id = json_obj['id']
-        self.name = json_obj['name'].encode('utf-8')
+        self.name = json_obj['name']
         self.desc = json_obj.get('desc', '')
         self.closed = json_obj['closed']
         self.url = json_obj['url']

--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
+from trello.compat import force_str
 
 
 class Checklist(object):
@@ -128,4 +129,4 @@ class Checklist(object):
             return None
 
     def __repr__(self):
-        return '<Checklist %s>' % self.id
+        return force_str(u'<Checklist %s>' % self.id)

--- a/trello/compat.py
+++ b/trello/compat.py
@@ -1,0 +1,15 @@
+import sys
+
+PY2 = sys.version_info > (3, 0)
+
+
+def force_str(s, encoding='utf-8'):
+    """
+    Converts `s` to the `str` type, regardless of the Python
+    version. This is useful for __repr__ return types, where a `str`
+    (bytes) is expected in Python 2 and a `str` (unicode string) is
+    expected in Python 3.
+    """
+    if PY2 and isinstance(s, unicode):  # noqa
+        s = s.encode(encoding)
+    return s

--- a/trello/label.py
+++ b/trello/label.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
+from trello.compat import force_str
 
 
 class Label(object):
@@ -22,7 +23,7 @@ class Label(object):
         """
         label = Label(board.client,
                       label_id=json_obj['id'],
-                      name=json_obj['name'].encode('utf-8'),
+                      name=json_obj['name'],
                       color=json_obj['color'])
         return label
 
@@ -31,11 +32,11 @@ class Label(object):
         return [cls.from_json(board, obj) for obj in json_objs]
 
     def __repr__(self):
-        return '<Label %s>' % self.name
+        return force_str(u'<Label %s>' % self.name)
 
     def fetch(self):
         """Fetch all attributes for this label"""
         json_obj = self.client.fetch_json('/labels/' + self.id)
-        self.name = json_obj['name'].encode('utf-8')
+        self.name = json_obj['name']
         self.color = json_obj['color']
         return self

--- a/trello/member.py
+++ b/trello/member.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
+from trello.compat import force_str
 
 
 class Member(object):
@@ -13,7 +14,7 @@ class Member(object):
         self.full_name = full_name
 
     def __repr__(self):
-        return '<Member %s>' % self.id
+        return force_str(u'<Member %s>' % self.id)
 
     def fetch(self):
         """Fetch all attributes for this member"""
@@ -43,14 +44,14 @@ class Member(object):
             '/members/' + self.id + '/cards',
             query_params={'filter': 'visible'})
         return sorted(cards, key=lambda card: card['dateLastActivity'])
-    
+
     def fetch_notifications(self, filters = []):
         """ Fetches all the notifications for this member """
         notifications = self.client.fetch_json(
             '/members/' + self.id + '/notifications',
             query_params={'filter': ",".join(filters)})
         return sorted(notifications, key=lambda notification: notification['date'])
-    
+
     @classmethod
     def from_json(cls, trello_client, json_obj):
         """
@@ -60,9 +61,9 @@ class Member(object):
         :json_obj: the member json object
         """
 
-        member = Member(trello_client, json_obj['id'], full_name=json_obj['fullName'].encode('utf-8'))
-        member.username = json_obj.get('username', '').encode('utf-8')
-        member.initials = json_obj.get('initials', '').encode('utf-8')
+        member = Member(trello_client, json_obj['id'], full_name=json_obj['fullName'])
+        member.username = json_obj.get('username', '')
+        member.initials = json_obj.get('initials', '')
         # cannot close an organization
         # organization.closed = json_obj['closed']
         return member

--- a/trello/organization.py
+++ b/trello/organization.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
 from trello.board import Board
+from trello.compat import force_str
 from trello.member import Member
 
 
@@ -22,15 +23,15 @@ class Organization(object):
         :trello_client: the trello client
         :json_obj: the board json object
         """
-        organization = Organization(trello_client, json_obj['id'], name=json_obj['name'].encode('utf-8'))
-        organization.description = json_obj.get('desc', '').encode('utf-8')
+        organization = Organization(trello_client, json_obj['id'], name=json_obj['name'])
+        organization.description = json_obj.get('desc', '')
         # cannot close an organization
         # organization.closed = json_obj['closed']
         organization.url = json_obj['url']
         return organization
 
     def __repr__(self):
-        return '<Organization %s>' % self.name
+        return force_str(u'<Organization %s>' % self.name)
 
     def fetch(self):
         """Fetch all attributes for this organization"""

--- a/trello/trellolist.py
+++ b/trello/trellolist.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
+from trello.compat import force_str
 
 
 class List(object):
@@ -27,12 +28,12 @@ class List(object):
         :board: the board object that the list belongs to
         :json_obj: the json list object
         """
-        list = List(board, json_obj['id'], name=json_obj['name'].encode('utf-8'))
+        list = List(board, json_obj['id'], name=json_obj['name'])
         list.closed = json_obj['closed']
         return list
 
     def __repr__(self):
-        return '<List %s>' % self.name
+        return force_str(u'<List %s>' % self.name)
 
     def fetch(self):
         """Fetch all attributes for this list"""


### PR DESCRIPTION
Fixes #118 
Fixes #135 

Following #135, here's my proposal for keeping unicode data internally and having safe `__repr__` implementations. More details can be found in the commit message.

Additional changes:

* Some README formatting fixes
* Replace deprecated `assertEquals` with `assertEqual` (avoids a warning on Python3)
* Add Tox support to easily run tests for a bunch of Python versions. I don't know what the project targets are, so I only put Python 2.7, 3.4 and 3.5.