### PR TITLE
Update repr() methods and fix unicode inconsistency

### DIFF
--- a/test/test_board.py
+++ b/test/test_board.py
@@ -18,7 +18,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:
@@ -30,7 +30,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEqual(card.name, name.encode('utf-8'))
+            self.assertEqual(card.name, name)
             return card
         except Exception as e:
             print(str(e))
@@ -145,27 +145,31 @@ class TrelloBoardTestCase(unittest.TestCase):
         test_list = test_board.add_list("test_list")
         test_list.add_card("test_card")
         open_boards = self._trello.list_boards(board_filter="open")
-        self.assertEqual(len([x for x in open_boards if x.name == "test_create_board".encode('utf-8')]), 1)
+        self.assertEqual(
+            len([x for x in open_boards if x.name == "test_create_board"]), 1)
 
     def test110_copy_board(self):
         boards = self._trello.list_boards(board_filter="open")
-        source_board = next( x for x in boards if x.name == "test_create_board".encode('utf-8'))
+        source_board = next(x for x in boards if x.name == "test_create_board")
         self._trello.add_board("copied_board", source_board=source_board)
         listed_boards = self._trello.list_boards(board_filter="open")
-        copied_board = next(iter([x for x in listed_boards if x.name == "copied_board".encode('utf-8')]), None)
+        copied_board = next(
+            (x for x in listed_boards if x.name == "copied_board"), None)
         self.assertIsNotNone(copied_board)
         open_lists = copied_board.open_lists()
         self.assertEqual(len(open_lists), 4) # default lists plus mine
         test_list = open_lists[0]
         self.assertEqual(len(test_list.list_cards()), 1)
-        test_card = next ( iter([ x for x in test_list.list_cards() if x.name == "test_card".encode('utf-8')]), None )
-        self.assertIsNotNone(test_card)
+        self.assertEqual(len([x for x in test_list.list_cards()
+                         if x.name == "test_card"]), 1)
 
     def test120_close_board(self):
         boards = self._trello.list_boards(board_filter="open")
         open_count = len(boards)
-        test_create_board = next( x for x in boards if x.name == "test_create_board".encode('utf-8')) # type: Board
-        copied_board = next( x for x in boards if x.name == "copied_board".encode('utf-8')) # type: Board
+        test_create_board = next(
+            x for x in boards if x.name == "test_create_board") # type: Board
+        copied_board = next(
+            x for x in boards if x.name == "copied_board") # type: Board
         test_create_board.close()
         copied_board.close()
         still_open_boards = self._trello.list_boards(board_filter="open")

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -18,7 +18,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:
@@ -30,7 +30,7 @@ class TrelloBoardTestCase(unittest.TestCase):
             card = self._list.add_card(name, description)
             self.assertIsNotNone(card, msg="card is None")
             self.assertIsNotNone(card.id, msg="id not provided")
-            self.assertEquals(card.name, name.encode('utf-8'))
+            self.assertEquals(card.name, name)
             return card
         except Exception as e:
             print(str(e))

--- a/test/test_checklist.py
+++ b/test/test_checklist.py
@@ -18,7 +18,7 @@ class TrelloChecklistTestCase(unittest.TestCase):
         cls._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
                                    token=os.environ['TRELLO_TOKEN'])
         for b in cls._trello.list_boards():
-            if b.name == os.environ['TRELLO_TEST_BOARD_NAME'].encode('utf-8'):
+            if b.name == os.environ['TRELLO_TEST_BOARD_NAME']:
                 cls._board = b
                 break
         if not cls._board:

--- a/trello/board.py
+++ b/trello/board.py
@@ -52,11 +52,13 @@ class Board(object):
         :json_obj: the json board object
         """
         if organization is None:
-            board = Board(client=trello_client, board_id=json_obj['id'], name=json_obj['name'].encode('utf-8'))
+            board = Board(client=trello_client, board_id=json_obj['id'],
+                          name=json_obj['name'])
         else:
-            board = Board(organization=organization, board_id=json_obj['id'], name=json_obj['name'].encode('utf-8'))
+            board = Board(organization=organization, board_id=json_obj['id'],
+                          name=json_obj['name'])
 
-        board.description = json_obj.get('desc', '').encode('utf-8')
+        board.description = json_obj.get('desc', '')
         board.closed = json_obj['closed']
         board.url = json_obj['url']
 
@@ -68,7 +70,12 @@ class Board(object):
         return board
 
     def __repr__(self):
-        return '<Board %s>' % self.name
+        if self.organization:
+            return ('Board(board_id=%r, name=%r, organization=%r)'
+                    % (self.id, self.organization, self.name))
+        else:
+            return ('Board(board_id=%r, name=%r, client=%r)'
+                    % (self.id, self.client, self.name))
 
     def fetch(self):
         """Fetch all attributes for this board"""
@@ -293,13 +300,13 @@ class Board(object):
         members = list()
         for obj in json_obj:
             m = Member(self.client, obj['id'])
-            m.status = obj.get('status', '').encode('utf-8')
+            m.status = obj.get('status', '')
             m.id = obj.get('id', '')
             m.bio = obj.get('bio', '')
             m.url = obj.get('url', '')
-            m.username = obj['username'].encode('utf-8')
-            m.full_name = obj['fullName'].encode('utf-8')
-            m.initials = obj.get('initials', '').encode('utf-8')
+            m.username = obj['username']
+            m.full_name = obj['fullName']
+            m.initials = obj.get('initials', '')
             members.append(m)
 
         return members

--- a/trello/board.py
+++ b/trello/board.py
@@ -72,10 +72,10 @@ class Board(object):
     def __repr__(self):
         if self.organization:
             return ('Board(board_id=%r, name=%r, organization=%r)'
-                    % (self.id, self.organization, self.name))
+                    % (self.id, self.name, self.organization))
         else:
             return ('Board(board_id=%r, name=%r, client=%r)'
-                    % (self.id, self.client, self.name))
+                    % (self.id, self.name, self.client))
 
     def fetch(self):
         """Fetch all attributes for this board"""

--- a/trello/card.py
+++ b/trello/card.py
@@ -123,7 +123,7 @@ class Card(object):
             raise Exception("key 'id' is not in json_obj")
         card = cls(parent,
                    json_obj['id'],
-                   name=json_obj['name'].encode('utf-8'))
+                   name=json_obj['name'])
         card.desc = json_obj.get('desc', '')
         card.due = json_obj.get('due', '')
         card.closed = json_obj['closed']
@@ -136,7 +136,7 @@ class Card(object):
         return card
 
     def __repr__(self):
-        return '<Card %s>' % self.name
+        return 'Card(%r, %r, name=%r)' % (self.board, self.id, self.name)
 
     def fetch(self, eager=True):
         """
@@ -147,7 +147,7 @@ class Card(object):
             '/cards/' + self.id,
             query_params={'badges': False})
         self.id = json_obj['id']
-        self.name = json_obj['name'].encode('utf-8')
+        self.name = json_obj['name']
         self.desc = json_obj.get('desc', '')
         self.closed = json_obj['closed']
         self.url = json_obj['url']

--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -128,4 +128,4 @@ class Checklist(object):
             return None
 
     def __repr__(self):
-        return '<Checklist %s>' % self.id
+        return '<Checklist %r>' % self.id

--- a/trello/label.py
+++ b/trello/label.py
@@ -22,7 +22,7 @@ class Label(object):
         """
         label = Label(board.client,
                       label_id=json_obj['id'],
-                      name=json_obj['name'].encode('utf-8'),
+                      name=json_obj['name'],
                       color=json_obj['color'])
         return label
 
@@ -31,11 +31,12 @@ class Label(object):
         return [cls.from_json(board, obj) for obj in json_objs]
 
     def __repr__(self):
-        return '<Label %s>' % self.name
+        return ('Label(%r, %r, %r, color=%r)'
+                % (self.client, self.id, self.name, self.color))
 
     def fetch(self):
         """Fetch all attributes for this label"""
         json_obj = self.client.fetch_json('/labels/' + self.id)
-        self.name = json_obj['name'].encode('utf-8')
+        self.name = json_obj['name']
         self.color = json_obj['color']
         return self

--- a/trello/member.py
+++ b/trello/member.py
@@ -13,7 +13,8 @@ class Member(object):
         self.full_name = full_name
 
     def __repr__(self):
-        return '<Member %s>' % self.id
+        return ('Member(%r, %r, full_name=%r)'
+                % (self.client, self.id, self.full_name))
 
     def fetch(self):
         """Fetch all attributes for this member"""
@@ -54,15 +55,14 @@ class Member(object):
     @classmethod
     def from_json(cls, trello_client, json_obj):
         """
-        Deserialize the organization json object to a member object
+        Deserialize the member json object to a member object
 
         :trello_client: the trello client
         :json_obj: the member json object
         """
 
-        member = Member(trello_client, json_obj['id'], full_name=json_obj['fullName'].encode('utf-8'))
-        member.username = json_obj.get('username', '').encode('utf-8')
-        member.initials = json_obj.get('initials', '').encode('utf-8')
-        # cannot close an organization
-        # organization.closed = json_obj['closed']
+        member = Member(trello_client, json_obj['id'],
+                        full_name=json_obj['fullName'])
+        member.username = json_obj.get('username', '')
+        member.initials = json_obj.get('initials', '')
         return member

--- a/trello/organization.py
+++ b/trello/organization.py
@@ -22,15 +22,16 @@ class Organization(object):
         :trello_client: the trello client
         :json_obj: the board json object
         """
-        organization = Organization(trello_client, json_obj['id'], name=json_obj['name'].encode('utf-8'))
-        organization.description = json_obj.get('desc', '').encode('utf-8')
+        organization = Organization(trello_client, json_obj['id'], name=json_obj['name'])
+        organization.description = json_obj.get('desc', '')
         # cannot close an organization
         # organization.closed = json_obj['closed']
         organization.url = json_obj['url']
         return organization
 
     def __repr__(self):
-        return '<Organization %s>' % self.name
+        return ('Organization(%r, %r, name=%r)'
+                % (self.client, self.id, self.name))
 
     def fetch(self):
         """Fetch all attributes for this organization"""

--- a/trello/trellolist.py
+++ b/trello/trellolist.py
@@ -27,12 +27,12 @@ class List(object):
         :board: the board object that the list belongs to
         :json_obj: the json list object
         """
-        list = List(board, json_obj['id'], name=json_obj['name'].encode('utf-8'))
+        list = List(board, json_obj['id'], name=json_obj['name'])
         list.closed = json_obj['closed']
         return list
 
     def __repr__(self):
-        return '<List %s>' % self.name
+        return 'List(%r, %r, name=%r)' % (self.board, self.id, self.name)
 
     def fetch(self):
         """Fetch all attributes for this list"""


### PR DESCRIPTION
__repr__ should return a valid Python expression to regenerate the
object where possible. Using the representation of strings also avoids
encoding issues between Python 2/3 and removes string/unicode
inconsistencies between attributes.
for attributes

Fixes #135 