### PR TITLE
README: fix hybrid markdow/rst syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,38 +10,38 @@ for feature requests, discussion and some development tracking.
 Install
 =======
 
-```
-pip install py-trello
-```
+::
+
+    pip install py-trello
 
 Usage
 =====
 
-```python
-from trello import TrelloClient
+.. code-block:: python
 
-client = TrelloClient(
-    api_key='your-key',
-    api_secret='your-secret',
-    token='your-oauth-token-key',
-    token_secret='your-oauth-token-secret'
-)
-```
+    from trello import TrelloClient
 
-Where `token` and `token_secret` come from the 3-legged OAuth process and
-`api_key` and `api_secret` are your Trello API credentials that are
+    client = TrelloClient(
+        api_key='your-key',
+        api_secret='your-secret',
+        token='your-oauth-token-key',
+        token_secret='your-oauth-token-secret'
+    )
+
+Where ``token`` and ``token_secret`` come from the 3-legged OAuth process and
+``api_key`` and ``api_secret`` are your Trello API credentials that are
 (`generated here <https://trello.com/1/appKey/generate>`_).
 
 Getting your Trello OAuth Token
 ===============================
 Make sure the following environment variables are set:
 
-* `TRELLO_API_KEY`
-* `TRELLO_API_SECRET`
+* ``TRELLO_API_KEY``
+* ``TRELLO_API_SECRET``
 
 These are obtained from the link mentioned above.
 
-`TRELLO_EXPIRATION` is optional. Set it to a string such as 'never' or '1day'.
+``TRELLO_EXPIRATION`` is optional. Set it to a string such as 'never' or '1day'.
 Trello's default OAuth Token expiration is 30 days.
 
 Default permissions are read/write.
@@ -51,27 +51,28 @@ https://trello.com/docs/gettingstarted/#getting-a-token-from-a-user
 
 Run
 
-```
-python ./trello/util.py
-```
+::
+
+    python ./trello/util.py
 
 Required Python modules
 =======================
 
-Found in `requirements.txt`
+Found in ``requirements.txt``
 
 Tests
 =====
-To run the tests, run `python -m unittest discover`. Four environment variables must be set:
 
-* `TRELLO_API_KEY`: your Trello API key
-* `TRELLO_TOKEN`: your Trello OAuth token
-* `TRELLO_TEST_BOARD_COUNT`: the number of boards in your Trello account
-* `TRELLO_TEST_BOARD_NAME`: name of the board to test card manipulation on. Must be unique, or the first match will be used
+To run the tests, run ``python -m unittest discover``. Four environment variables must be set:
+
+* ``TRELLO_API_KEY``: your Trello API key
+* ``TRELLO_TOKEN``: your Trello OAuth token
+* ``TRELLO_TEST_BOARD_COUNT``: the number of boards in your Trello account
+* ``TRELLO_TEST_BOARD_NAME``: name of the board to test card manipulation on. Must be unique, or the first match will be used
 
 To run tests across various Python versions,
-[tox](https://tox.readthedocs.io/en/latest/) is supported. Install it
-and simply run `tox` from the `py-trello` directory.
+`tox <https://tox.readthedocs.io/en/latest/>`_ is supported. Install it
+and simply run ``tox`` from the ``py-trello`` directory.
 
 Contributors
 ============


### PR DESCRIPTION
In https://github.com/sarumont/py-trello/commit/0023119401dd2e04dd7d214cde583eca96a422de I assumed the README was in markdown format, but it was in fact RST. I didn't catch the extension…

This commit brings proper RST rendering.