### PR TITLE
Add Board.list_lists

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -140,6 +140,13 @@ class Board(object):
             query_params={'cards': 'none', 'filter': list_filter})
         return [List.from_json(board=self, json_obj=obj) for obj in json_obj]
 
+    def list_lists(self, list_filter='all'):
+        """Get lists from filter
+
+        :rtype: list of List
+        """
+        return self.get_lists(list_filter=list_filter)
+
     def get_labels(self, fields='all', limit=50):
         """Get label
 


### PR DESCRIPTION
This matches the API that TrelloClient has for boards (i.e. list_*
returns all lists by default, but takes a filter as an option).