### PR TITLE
Add missing initials for members of an organization (fixes #176)

### DIFF
--- a/trello/organization.py
+++ b/trello/organization.py
@@ -71,5 +71,6 @@ class Organization(object):
     def get_members(self):
         json_obj = self.client.fetch_json(
             '/organizations/' + self.id + '/members',
-            query_params={'filter': 'all'})
+            query_params={'filter': 'all',
+                          'fields': 'id,fullName,username,initials'})
         return [Member.from_json(trello_client=self.client, json_obj=obj) for obj in json_obj]


### PR DESCRIPTION
Unless a list of fields is supplied, the list of members for an organization
will only include the member full name and username.  This means that a
list of member objects created from an organization will lack data in the
'initials' field that would exist if the member object were created by id.