### PR TITLE
Implement partial search API (Fixes #178)

### DIFF
--- a/trello/organization.py
+++ b/trello/organization.py
@@ -26,8 +26,6 @@ class Organization(object):
         """
         organization = Organization(trello_client, json_obj['id'], name=json_obj['name'])
         organization.description = json_obj.get('desc', '')
-        # cannot close an organization
-        # organization.closed = json_obj['closed']
         organization.url = json_obj['url']
         return organization
 
@@ -39,7 +37,6 @@ class Organization(object):
         json_obj = self.client.fetch_json('/organizations/' + self.id)
         self.name = json_obj['name']
         self.description = json_obj.get('desc', '')
-        self.closed = json_obj['closed']
         self.url = json_obj['url']
 
     def all_boards(self):

--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -277,7 +277,10 @@ class TrelloClient(object):
         :param card_ids: Comma-separated list of cards to limit search
 
         :return: All objects matching the search criterial.  These can
-            be Cards, Boards, Organizations, and Members
+            be Cards, Boards, Organizations, and Members.  The attributes
+            of the objects in the results are minimal; the user must call
+            the fetch method on the resulting objects to get a full set
+            of attributes populated.
         :rtype list:
         """
 


### PR DESCRIPTION
The search API has a rich set of arguments, this patch implements a basic set to limit queries to particular object types or limit the search to a set of objects.