### PR TITLE
Make card.fetch_actions() and list.fetch_actions() return the result

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -274,6 +274,7 @@ class Card(TrelloBase):
                            "since": since,
                            "before": before})
         self.actions = json_obj
+        return self.actions
 
     def attriExp(self, multiple):
         """

--- a/trello/trellolist.py
+++ b/trello/trellolist.py
@@ -126,6 +126,7 @@ class List(TrelloBase):
             '/lists/' + self.id + '/actions',
             query_params={'filter': action_filter})
         self.actions = json_obj
+        return self.actions
 
     def _set_remote_attribute(self, attribute, value):
         self.client.fetch_json(


### PR DESCRIPTION
board.fetch_actions() returns the result of the API call. For some reason
card and list.fetch_actions() just set self.actions but don't return the
result. This PR just makes all the methods have the same signature.
