### PR TITLE
Handle dateLastActivity being empty

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -394,4 +394,5 @@ class Board(TrelloBase):
 		"""
 		json_obj = self.client.fetch_json(
                 '/boards/{0}/dateLastActivity'.format(self.id))
-		return dateparser.parse(json_obj['_value'])
+		if json_obj['_value']:
+			return dateparser.parse(json_obj['_value'])


### PR DESCRIPTION
https://github.com/sarumont/py-trello/commit/a94a8134c340e755259b1908ddaebc1dcffc76cb
attempted to keep compatibility by providing a date_last_activity attribute despite
the dateLastActivity key no longer existing in the board JSON. I suspect the reason
it was removed is because it can sometimes be empty (ie when no activity has happened
on a board yet).

This change stops dateparser blowing up if the field is empty

Now that dateLastActivity isn't a key in the board JSON, it