### PR TITLE
Organization timezone set to UTC (to avoud an issue)

### DIFF
--- a/test/test_card.py
+++ b/test/test_card.py
@@ -59,7 +59,7 @@ class TrelloBoardTestCase(unittest.TestCase):
         self.assertIsNotNone(card.list_id)
         self.assertIsNotNone(card.comments)
         self.assertIsNotNone(card.checklists)
-        self.assertIsInstance(card.create_date, datetime)
+        self.assertIsInstance(card.created_date, datetime)
 
     def test42_add_card_with_comments_fetch(self):
         name = "Card with comments"

--- a/trello/organization.py
+++ b/trello/organization.py
@@ -8,7 +8,7 @@ from trello.member import Member
 
 class Organization(TrelloBase):
 
-    TIMEZONE = None
+    TIMEZONE = 'UTC'
 
     """
     Class representing an organization


### PR DESCRIPTION
Organization.TIMEZONE is None by default so when we try to use pytz.timezone(card.py#L376 and card.py#L473) we obtain an exception

This change set the default Organization.TIMEZONE to 'UTC' to workaround the problem. I think that a better solution is to detect the local configuration using tzlocal for example.
If you are ok with this change I also can send  a PR.

BTW I also fixed a type in the test_card that use a wrong name for a property.