### PR TITLE
Add the option to choose the third authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Where ``token`` and ``token_secret`` come from the 3-legged OAuth process and
 ``api_key`` and ``api_secret`` are your Trello API credentials that are
 (`generated here <https://trello.com/1/appKey/generate>`_).
 
+To use without 3-legged OAuth, use only ``api_key`` and ``api_secret`` on client.
 
 Working with boards
 --------------------

--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -127,7 +127,7 @@ class TrelloClient(object):
         :param permission_level: Permission level, defaults to private
         :rtype: Board
         """
-        post_args={'name': board_name, 'prefs_permissionLevel': permission_level}
+        post_args = {'name': board_name, 'prefs_permissionLevel': permission_level}
         if source_board is not None:
             post_args['idBoardSource'] = source_board.id
         if organization_id is not None:
@@ -207,6 +207,10 @@ class TrelloClient(object):
         if uri_path[0] == '/':
             uri_path = uri_path[1:]
         url = 'https://api.trello.com/1/%s' % uri_path
+
+        if self.oauth is None:
+            query_params['key'] = self.api_key
+            query_params['token'] = self.api_secret
 
         # perform the HTTP requests, if possible uses OAuth authentication
         response = requests.request(http_method, url, params=query_params,


### PR DESCRIPTION
Note:
Some scripts would not be automated with the third factor.
We generally use api_key and api_secret.

With this modification this tool would be useful for both Oauth 
users and users who do not use it.