### PR TITLE
Third authentication: initialize TrelloClient correctly

### DIFF
--- a/test/test_card.py
+++ b/test/test_card.py
@@ -6,7 +6,7 @@ import os
 from trello import TrelloClient, ResourceUnavailable
 
 
-class TrelloBoardTestCase(unittest.TestCase):
+class TrelloCardTestCase(unittest.TestCase):
     """
     Tests for TrelloClient API. Note these test are in order to
     preserve dependencies, as an API integration cannot be tested
@@ -136,6 +136,7 @@ def suite():
     # tests = ['test01_list_boards', 'test10_board_attrs', 'test20_add_card']
     # return unittest.TestSuite(map(TrelloBoardTestCase, tests))
     return unittest.TestLoader().loadTestsFromTestCase(TrelloBoardTestCase)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_trello_client.py
+++ b/test/test_trello_client.py
@@ -112,10 +112,33 @@ class TrelloClientTestCase(unittest.TestCase):
                           self._trello.get_card, '0')
 
 
+class TrelloClientTestCaseWithoutOAuth(unittest.TestCase):
+    """
+
+    Tests for TrelloClient API when OAuth not activated.
+
+    """
+
+    def setUp(self):
+        self._trello = TrelloClient(os.environ['TRELLO_API_KEY'],
+                                    api_secret=os.environ['TRELLO_TOKEN'])
+
+    def test01_oauth_not_activated(self):
+        self.assertIsNone(self._trello.oauth)
+
+
 def suite():
-    # tests = ['test01_list_boards', 'test10_board_attrs', 'test20_add_card']
-    # return unittest.TestSuite(map(TrelloClientTestCase, tests))
-    return unittest.TestLoader().loadTestsFromTestCase(TrelloClientTestCase)
+    test_classes_to_run = [TrelloClientTestCase,
+                           TrelloClientTestCaseWithoutOAuth]
+
+    loader = unittest.TestLoader()
+
+    suites_list = []
+    for test_class in test_classes_to_run:
+        suite = loader.loadTestsFromTestCase(test_class)
+        suites_list.append(suite)
+
+    return unittest.TestSuite(suites_list)
 
 
 if __name__ == "__main__":

--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -38,7 +38,7 @@ class TrelloClient(object):
         """
 
         # client key and secret for oauth1 session
-        if api_key or token:
+        if token or token_secret:
             self.oauth = OAuth1(client_key=api_key, client_secret=api_secret,
                                 resource_owner_key=token, resource_owner_secret=token_secret)
         else:


### PR DESCRIPTION
Fixes #225
When TrelloClient initalise itself, it should look if token and
token_secret are provided to enable OAuth, otherwise, fallback to 3rd
authentication

Signed-off-by: Romain Beuque <romain.beuque@gmail.com>