### PR TITLE
Fixes Issue #247 KeyError: 'customFieldItems'

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -251,36 +251,39 @@ class Board(TrelloBase):
 		    	post_args={'id': label_id}, )
 		return json_obj
 
-	def all_cards(self):
+	def all_cards(self, custom_field_items='true'):
 		"""Returns all cards on this board
 
 		:rtype: list of Card
 		"""
 		filters = {
 			'filter': 'all',
-			'fields': 'all'
+			'fields': 'all',
+			'customFieldItems': custom_field_items
 		}
 		return self.get_cards(filters)
 
-	def open_cards(self):
+	def open_cards(self, custom_field_items='true'):
 		"""Returns all open cards on this board
 
 		:rtype: list of Card
 		"""
 		filters = {
 			'filter': 'open',
-			'fields': 'all'
+			'fields': 'all',
+			'customFieldItems': custom_field_items
 		}
 		return self.get_cards(filters)
 
-	def closed_cards(self):
+	def closed_cards(self, custom_field_items='true'):
 		"""Returns all closed cards on this board
 
 		:rtype: list of Card
 		"""
 		filters = {
 			'filter': 'closed',
-			'fields': 'all'
+			'fields': 'all',
+			'customFieldItems': custom_field_items
 		}
 		return self.get_cards(filters)
 


### PR DESCRIPTION
The previous support for custom fields added to py-trello did not
add the parameter[1] required to retrieve custom field items on cards.
This resulted in an error when calling any method to reteive cards on
a given board.

This patch adds the support for retrieving custom field items when
retrieving collections of cards by adding the designated
"customFieldItems" parameter to the open_cards, closed_cards and
all_cards methods.  The value is defaulted to 'true', but allows
for override for the cases you don't need the customFieldItems.