### PR TITLE
Modifies Cards.from_json to not require customFieldItems

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -154,7 +154,8 @@ class Card(TrelloBase):
         card.idBoard = json_obj['idBoard']
         card.idList = json_obj['idList']
         card.idShort = json_obj['idShort']
-        card.customFields = CustomField.from_json_list(card, json_obj['customFieldItems'])
+        card.customFields = CustomField.from_json_list(
+            card, json_obj.get('customFieldItems', {}))
         card.labels = Label.from_json_list(card.board, json_obj['labels'])
         card.dateLastActivity = dateparser.parse(json_obj['dateLastActivity'])
         if "attachments" in json_obj:


### PR DESCRIPTION
The Cards.from_json method expects that each time you query for
a card, the 'customFieldItems' key will be present in the json
returned from the API.  This causes an error if custom fields is
not enabled for the board or in the case where you're adding a
new card.

This patch changes the way the dictionary is accessed so that
when the customFieldItems key is not present it will return a
json collection with 0 length instead of raising a keyError.