### PR TITLE
Add warning that running tests will delete cards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,8 @@ To run the tests, run ``python -m unittest discover``. Four environment variable
 * ``TRELLO_TEST_BOARD_COUNT``: the number of boards in your Trello account
 * ``TRELLO_TEST_BOARD_NAME``: name of the board to test card manipulation on. Must be unique, or the first match will be used
 
+*WARNING*: The tests will delete all cards on the board called `TRELLO_TEST_BOARD_NAME`!
+
 To run tests across various Python versions,
 `tox <https://tox.readthedocs.io/en/latest/>`_ is supported. Install it
 and simply run ``tox`` from the ``py-trello`` directory.


### PR DESCRIPTION
Add a warning to the README that running the tests will delete all cards on the board `TRELLO_TEST_BOARD_NAME`.

For some people, this might be surprising. In the end a refactoring of the tests to not do that would probably be the best.