### PR TITLE
Add check and fix for python3 unicode assertion

### DIFF
--- a/trello/customfield.py
+++ b/trello/customfield.py
@@ -2,8 +2,13 @@
 from __future__ import with_statement, print_function, absolute_import
 
 import time
+import sys
 from trello import TrelloBase
 from trello.compat import force_str
+
+is_python3 = sys.version_info.major == 3
+if is_python3:
+	unicode = str
 
 
 class CustomFieldDefinition(TrelloBase):


### PR DESCRIPTION
Add workaround for python3 for the unicode assertions. All strings in python3 are unicode by default