### PR TITLE
Fix timezone problem with tz aware datetime

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -523,7 +523,7 @@ class Card(TrelloBase):
 
         :due: a datetime object
         """
-        datestr = due.strftime('%Y-%m-%dT%H:%M:%S')
+        datestr = due.isoformat()
         self._set_remote_attribute('due', datestr)
         self.due = datestr
 


### PR DESCRIPTION
There is a tip in the [this issue](https://github.com/trello/api-docs/issues/107) to use iso-formated date to fix timezone problems