### PR TITLE
Lazy load property trello.Board.date_last_activity

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -38,7 +38,7 @@ class Board(TrelloBase):
 			self.client = organization.client
 		self.id = board_id
 		self.name = name
-		self.date_last_activity = self.get_last_activity()
+		self._date_last_activity = None
 		self.customFieldDefinitions = None
 
 	@classmethod
@@ -422,6 +422,12 @@ class Board(TrelloBase):
 
 		self.actions = json_obj
 		return self.actions
+
+	@property
+	def date_last_activity(self):
+		if self._date_last_activity is None:
+			self._date_last_activity = self.get_last_activity()
+		return self._date_last_activity
 
 	def get_last_activity(self):
 		"""Return the date of the last action done on the board.


### PR DESCRIPTION
This change puts the `get_last_activity` method behind a lazy-loaded property decorator, like many other properties in this library.

I found that some initialization-time network calls were being made by `trello.Board` when investigating a performance regression with [a project using py-trello](https://github.com/delucks/gtd.py) bumping versions between 0.9.0 and 0.11.3. The addition of `get_last_activity` to the constructor of `trello.Board` means that a call to `trello.TrelloConnection.list_boards` will incur N+1 network round-trips, where N is the count of boards returned by `list_boards`. This changes that behavior, so now `list_boards` only performs 1 network call.

All tests pass as well!