### PR TITLE
Add documentation blurb about TRELLO_TEST_STAR_COUNT to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ To run the tests, run ``python -m unittest discover``. Four environment variable
 * ``TRELLO_TOKEN``: your Trello OAuth token
 * ``TRELLO_TEST_BOARD_COUNT``: the number of boards in your Trello account
 * ``TRELLO_TEST_BOARD_NAME``: name of the board to test card manipulation on. Must be unique, or the first match will be used
+* ``TRELLO_TEST_STAR_COUNT``: the number of stars on your test Trello board
 
 *WARNING*: The tests will delete all cards on the board called `TRELLO_TEST_BOARD_NAME`!
 


### PR DESCRIPTION
Noticed this exported variable was missing when running the tests for my other PR