### PR TITLE
fixed KeyError / missing subscribed key in Trello lists

### DIFF
--- a/trello/trellolist.py
+++ b/trello/trellolist.py
@@ -51,7 +51,8 @@ class List(TrelloBase):
         self.name = json_obj['name']
         self.closed = json_obj['closed']
         self.pos = json_obj['pos']
-        self.subscribed = json_obj['subscribed']
+        if 'subscribed' in json_obj:
+            self.subscribed = json_obj['subscribed']
 
     def list_cards(self, card_filter="open", actions=None, query={}):
         """Lists all cards in this list"""


### PR DESCRIPTION
I've started getting the following error while calling `TrelloList.fetch()`

```
  File ".../venv/lib/python3.6/site-packages/trello/trellolist.py", line 56, in fetch
    self.subscribed = json_obj['subscribed']
KeyError: 'subscribed'
```

This commit resolves the immediate issue in the same way that `from_json()` handles it.

There may be further implications that I've not been made aware of.