### PR TITLE
Fetch comments from copied cards

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -222,7 +222,7 @@ class Card(TrelloBase):
         comments = []
 
         if (force is True) or (self.badges['comments'] > 0):
-            query_params = {'filter': 'commentCard'}
+            query_params = {'filter': 'commentCard,copyCommentCard'}
             if limit is not None:
                 query_params['limit'] = limit
             comments = self.client.fetch_json(


### PR DESCRIPTION
I stumbled upon this while writing a backup script. For a copied card, everything that I wanted was there, except for the comments. It seems the action is different in that situation.

Some test output, prior this change:

```
### Sample Card

2019-05-07T16:00:00.000Z

Sample description

1 checklists
1 comments
1 attachments

### Copied Card

2019-05-07T16:00:00.000Z

Sample description

1 checklists
0 comments
1 attachments
```

After, the `0 comments` becomes `1 comments`.