### PR TITLE
Add module command for OAuth token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 .tox/
 .DS_Store
 example
+venv
+.env

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Run
 
 ::
 
-    python ./trello/util.py
+    python -m trello oauth
 
 Required Python modules
 =======================

--- a/trello/__main__.py
+++ b/trello/__main__.py
@@ -1,0 +1,17 @@
+import sys
+
+from trello.util import create_oauth_token
+
+
+def main():
+    try:
+        command = sys.argv[1]
+    except IndexError:
+        return
+
+    if command == "oauth":
+        create_oauth_token()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trello/__main__.py
+++ b/trello/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 
 from trello.util import create_oauth_token
@@ -15,3 +16,5 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/trello/util.py
+++ b/trello/util.py
@@ -87,7 +87,4 @@ def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=
 
     return access_token
 
-if __name__ == '__main__':
-    create_oauth_token()
-
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
i.e., `python -m trello oauth`

This allows creating an OAuth token from any virtual environment where this package is installed, whereas the prior instructions required executing the source code directly.

This could be improved by using `argparse` for command-line parsing and a help message. Happy to do that (and other improvements) if there's interest.