### PR TITLE
Allow set_custom_field to accept an empty value

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -571,11 +571,18 @@ class Card(TrelloBase):
             custom_field {custom field object} -- Custom Field Object (board.get_custom_field_definitions()[0])
 
         """
-        if custom_field.field_type in ['text', 'number', 'date', 'checked']: 
-            post_args = {'value': {str(custom_field.field_type): value}}
-        else: 
-            list_field_id = [
-                x for x, y in custom_field.list_options.items() if y == value][0]
+        if custom_field.field_type in ['text', 'number', 'date', 'checked']:
+            if value == "":
+                post_args = {'value': ""}
+            else:
+                post_args = {'value': {str(custom_field.field_type): value}}
+        else:
+            if value == "":
+                list_field_id = ""
+            else:
+                try:
+                    list_field_id = [
+                        x for x, y in custom_field.list_options.items() if y == value][0]
             post_args = {'idValue': list_field_id}
 
         self.client.fetch_json(


### PR DESCRIPTION
The Trello API allows clearing a custom field's value by sending an
empty PUT request (see
https://developer.atlassian.com/cloud/trello/guides/rest-api/getting-started-with-custom-fields/#clearing-customfielditems).
In keeping with that, this commit allows the `card.set_custom_field`
method to clear the given custom field when passed an empty string.
It's very simple - if the value is empty, it skips giving it a type and
just sends the empty JSON, causing the field in Trello to be unset.

In the future, having a dedicated `clear_custom_field` may make more
sense, but I decided to put the functionality in `set_custom_field` so as
to match the structure of the actual REST API more closely

This change has not been formally tested, since the provided test suite doesn't test custom fields and I didn't get around to writing my own, but anecdotally, I've been using this version of the method on my own system for a while with no issue