### PR TITLE
On error in create_hook, there is no way to understand why it's failed 

### DIFF
--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -280,7 +280,7 @@ class TrelloClient(object):
             hook_id = response.json()['id']
             return WebHook(self, token, hook_id, desc, id_model, callback_url, True)
         else:
-            return False
+            raise Exception("Webhook creating failed: %s", response.data)
 
     def search(self, query, partial_match=False, models=[],
                board_ids=[], org_ids=[], card_ids=[], cards_limit=10):

--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -280,7 +280,7 @@ class TrelloClient(object):
             hook_id = response.json()['id']
             return WebHook(self, token, hook_id, desc, id_model, callback_url, True)
         else:
-            raise Exception("Webhook creating failed: %s", response.data)
+            raise Exception("Webhook creating failed: %s" % response.text)
 
     def search(self, query, partial_match=False, models=[],
                board_ids=[], org_ids=[], card_ids=[], cards_limit=10):


### PR DESCRIPTION
Consider this as a bug report, cause I'm not sure what is the preferred way to handle such exceptions