### PR TITLE
Fixed a problem with fetching checklists

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -159,6 +159,7 @@ class Card(TrelloBase):
         card.badges = json_obj['badges']
         card.customFields = card.fetch_custom_fields(json_obj=json_obj)
         card.countCheckItems = json_obj['badges']['checkItems']
+        card.countCheckLists = len(json_obj['idChecklists'])
         card._labels = Label.from_json_list(card.board, json_obj['labels'])
         card.dateLastActivity = dateparser.parse(json_obj['dateLastActivity'])
         if "attachments" in json_obj:
@@ -244,7 +245,7 @@ class Card(TrelloBase):
 
     def fetch_checklists(self):
 
-        if self.countCheckItems == 0:
+        if self.countCheckLists == 0:
             return []
         
         if not hasattr(self, "checked") or self.checked is None:


### PR DESCRIPTION
If you have a card with many checklist but no items inside them fetch_checklist cannot find any checklist.

The reason for that is that ```fetch_checklists``` does this:
```python
if self.countCheckItems == 0:
    return []
```
and ```self.countCheckItems``` is created in this way:
```python
card.countCheckItems = json_obj['badges']['checkItems']
```
So that means even if ```json_obj['idChecklists']``` has many checklists that's not considered at all by ```fetch_checklists```, therefore  for every card with only empty checklists it's impossible to get those checklist and eventually edit their items.

<hr>

I don't think it's intendend behaviour to have "phantoms" checklists that you can't find with **py-trello** but that the user can see, so i opened this PR.

The code seems to be working for me, tried with:
- cards with checklists with items
- cards with checklists with no items
- cards without checklists
