### PR TITLE
fix last_activity typo

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -69,7 +69,7 @@ class Board(TrelloBase):
 
 	def __repr__(self):
 		return force_str(f'<Board (name: {self.name}) (id: {self.id})'
-						+ f' (last_acitity: {self._date_last_activity})'
+						+ f' (last_activity: {self._date_last_activity})'
 						  f' (client: {self.client}) >')
 
 	def fetch(self):


### PR DESCRIPTION
Heyo,

Was testing out py-trello and noticed a small typo of "last_acitity" in the output of `client.list_boards()`:

```
>>> client.list_boards()
[<Board (name: Example Trello Board) (id: 12345) (last_acitity: None) (client: <trello.trelloclient.TrelloClient object at 0x10c894be0>) >, ... ]
```

Hope this PR helps to fix that. 🙂 