### PR TITLE
Fix dealing with duplicate checklist item names

### DIFF
--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -38,12 +38,12 @@ class Checklist(TrelloBase):
         self.items.append(json_obj)
         return json_obj
 
-    def delete_checklist_item(self, name):
+    def delete_checklist_item(self, item_or_name):
         """Delete an item on this checklist
 
-        :name: name of the checklist item to delete
+        :item_or_name: name or item object of the checklist item to delete 
         """
-        ix = self._get_item_index(name)
+        ix = self._get_item_index(item_or_name)
         if ix is None:
             return
 
@@ -55,10 +55,12 @@ class Checklist(TrelloBase):
 
     def clear(self):
         """Clear checklist by removing all checklist items"""
-        # iterate over names as list is modified while iterating and this breaks
+        # copy item list to prevent modifying while iterating, which would break
         # for-loops behaviour
-        for name in [item['name'] for item in self.items]:
-            self.delete_checklist_item(name)
+        old_items = items[:] 
+        for item in old_items:
+            self.delete_checklist_item(item)
+
 
     def set_checklist_item(self, name, checked):
         """Set the state of an item on this checklist
@@ -167,11 +169,11 @@ class Checklist(TrelloBase):
             '/checklists/%s' % self.id,
             http_method='DELETE')
 
-    def _get_item_index(self, name):
+    def _get_item_index(self, item_or_name):
         """Locate the index of the checklist item"""
         try:
-            [ix] = [i for i in range(len(self.items)) if
-                    self.items[i]['name'] == name]
+            ix = [i for i, item in enumerate(self.items) if
+                    item['name'] == item_or_name or item == item_or_name][0]
             return ix
         except ValueError:
             return None


### PR DESCRIPTION
Fixes both #325 and the underlying issue: when checklist item names were duplicate within a given checklist, the method `Checklist._get_item_index` would fail to find their index.

To fix #325, `Checklist._get_item_index` was patched to select the first item with the given name.
To fix the underlying issue (that the user could not specify a checklist item other than by name) while preserving backwards compatibility, the `_get_item_index` and `delete_checklist_item` were updated to allow taking a checklist item object as argument, and the `clear` method was changed to loop over such objects in order to prevent checklist items with duplicate names to not all be removed.