### PR TITLE
DEPRECATE enabling and disabling power ups

### DIFF
--- a/trello/board.py
+++ b/trello/board.py
@@ -68,7 +68,9 @@ class Board(TrelloBase):
 		return board
 
 	def __repr__(self):
-		return force_str(u'<Board %s>' % self.name)
+		return force_str(f'<Board (name: {self.name}) (id: {self.id})'
+						+ f' (last_activity: {self._date_last_activity})'
+						  f' (client: {self.client}) >')
 
 	def fetch(self):
 		"""Fetch all attributes for this board"""
@@ -224,8 +226,8 @@ class Board(TrelloBase):
 			arguments["pos"] = pos
 		
 		json_obj = self.client.fetch_json(
-			    '/customFields/{0}'.format(custom_field_definition_id),
-			    http_method='PUT',
+				'/customFields/{0}'.format(custom_field_definition_id),
+				http_method='PUT',
 				post_args=arguments, )
 		return json_obj
 
@@ -237,8 +239,8 @@ class Board(TrelloBase):
 		:rtype: json
 		"""
 		json_obj = self.client.fetch_json(
-			    '/customFields/{0}'.format(custom_field_definition_id),
-			    http_method='DELETE', )
+				'/customFields/{0}'.format(custom_field_definition_id),
+				http_method='DELETE', )
 		return json_obj
 	
 	def get_custom_field_list_options(self,custom_field_definition_id,values_only=False):
@@ -373,9 +375,9 @@ class Board(TrelloBase):
 		:rtype: json
 		"""
 		json_obj = self.client.fetch_json(
-			    '/labels/{0}'.format(label_id),
-			    http_method='DELETE',
-		    	post_args={'id': label_id}, )
+				'/labels/{0}'.format(label_id),
+				http_method='DELETE',
+				post_args={'id': label_id}, )
 		return json_obj
 
 	def all_cards(self, custom_field_items='true'):
@@ -574,7 +576,7 @@ class Board(TrelloBase):
 		:rtype: datetime.datetime
 		"""
 		json_obj = self.client.fetch_json(
-                '/boards/{0}/dateLastActivity'.format(self.id))
+				'/boards/{0}/dateLastActivity'.format(self.id))
 		if json_obj['_value']:
 			return dateparser.parse(json_obj['_value'])
 	def get_power_ups(self, board_id=None, name='', filters=None):

--- a/trello/board.py
+++ b/trello/board.py
@@ -68,9 +68,7 @@ class Board(TrelloBase):
 		return board
 
 	def __repr__(self):
-		return force_str(f'<Board (name: {self.name}) (id: {self.id})'
-						+ f' (last_activity: {self._date_last_activity})'
-						  f' (client: {self.client}) >')
+		return force_str(u'<Board %s>' % self.name)
 
 	def fetch(self):
 		"""Fetch all attributes for this board"""
@@ -189,7 +187,7 @@ class Board(TrelloBase):
 		:name: name for the field
 		:type: type of field: "checkbox", "list", "number", "text", "date"
 		:options: list of options for field, only valid for "list" type
-		:display_on_card: boolean whether this field should be shown on the front of cards
+		:display_on_card: boolean whether this field should be shown on the front of cards 
 		:pos: position of the list: "bottom", "top" or a positive number
 		:return: the custom_field_definition
 		:rtype: CustomFieldDefinition
@@ -286,7 +284,7 @@ class Board(TrelloBase):
 		"""
 
 		json_obj = self.client.fetch_json(
-				'customFields/{0}/options/{0}'.format(custom_field_definition_id,option_id),
+				'customFields/{0}/options/{1}'.format(custom_field_definition_id,option_id),
 				http_method='GET',
 				)
 		# if values_only:
@@ -303,7 +301,7 @@ class Board(TrelloBase):
 		"""
 
 		json_obj = self.client.fetch_json(
-				'customFields/{0}/options/{0}'.format(custom_field_definition_id,option_id),
+				'customFields/{0}/options/{1}'.format(custom_field_definition_id,option_id),
 				http_method='DELETE',
 				)
 		# if values_only:
@@ -597,6 +595,8 @@ class Board(TrelloBase):
 			 http_method='GET',post_args=arguments, )
 		return list([PowerUp.from_json(self, json_obj=json) for json in json_obj])
 	def enable_power_up(self, powerup_id,board_id=None):
+		from warnings import warn
+		warn("Atlassian has DEPRECATED enabling power ups! enable_power_up will be updated once an alternative becomes available",DeprecationWarning,stacklevel=2)
 		if board_id is None:
 			board_id = self.id
 		json_obj = self.client.fetch_json(
@@ -604,7 +604,9 @@ class Board(TrelloBase):
 			http_method='POST',
 			post_args={'idPlugin':powerup_id},)
 		return json_obj
-	def disable_power_up(self, powerup_id, board_id=None,):
+	def disable_power_up(self, powerup_id, board_id=None):
+		from warnings import warn
+		warn("Atlassian has DEPRECATED disabling power ups! disable_power_up will be updated once an alternative becomes available",DeprecationWarning,stacklevel=2)
 		if board_id is None:
 			board_id = self.id
 		json_obj = self.client.fetch_json(

--- a/trello/member.py
+++ b/trello/member.py
@@ -24,7 +24,6 @@ class Member(TrelloBase):
         json_obj = self.client.fetch_json(
             '/members/' + self.id,
             query_params={'badges': False})
-        self.email = json_obj['email']
         self.status = json_obj['status']
         self.id = json_obj.get('id', '')
         self.bio = json_obj.get('bio', '')
@@ -32,6 +31,7 @@ class Member(TrelloBase):
         self.username = json_obj['username']
         self.full_name = json_obj['fullName']
         self.initials = json_obj['initials']
+        self.json_obj = json_obj
         return self
 
     def fetch_comments(self):
@@ -81,6 +81,5 @@ class Member(TrelloBase):
         member = Member(trello_client, json_obj['id'], full_name=json_obj['fullName'])
         member.username = json_obj.get('username', '')
         member.initials = json_obj.get('initials', '')
-        # cannot close an organization
-        # organization.closed = json_obj['closed']
+        member.json_obj = json_obj
         return member


### PR DESCRIPTION
Atlassian DEPRECATED enabling and disabling power-ups. I've added a warning message. I'm open to an alternative like raising an exception.

https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-boardplugins-get
https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-boardplugins-idplugin-delete