### PR TITLE
Correction for when checked is None

### DIFF
--- a/trello/checklist.py
+++ b/trello/checklist.py
@@ -19,7 +19,7 @@ class Checklist(TrelloBase):
         self.items = sorted(obj['checkItems'], key=lambda items: items.get('pos'))
         for i in self.items:
             i['checked'] = False
-            for cis in checked:
+            for cis in checked or []:
                 if cis['idCheckItem'] == i['id'] and cis['state'] == 'complete':
                     i['checked'] = True
 


### PR DESCRIPTION
The value of checked in __init__ can sometimes be None if the checklist that is being initialized has no checked items, which makes the for loop starting at line 22 error out with TypeError: 'NoneType' object is not iterable.