### PR TITLE
Add HTTP User-Agent to fetchJSON

### DIFF
--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -12,6 +12,7 @@ from trello.webhook import WebHook
 from trello.exceptions import *
 from trello.label import Label
 from trello.star import Star
+from trello.util import generate_user_agent
 
 try:
     # PyOpenSSL works around some issues in python ssl modules
@@ -214,6 +215,9 @@ class TrelloClient(object):
             query_params = {}
         if post_args is None:
             post_args = {}
+
+        # add user agent header to fetch_json requests
+        headers['User-Agent'] = generate_user_agent()
 
         # if files specified, we don't want any data
         data = None

--- a/trello/util.py
+++ b/trello/util.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement, print_function, absolute_import
 import os
+import platform
 from requests_oauthlib import OAuth1Session
+
+def generate_user_agent():
+    sys_platform = platform.system()
+
+    user_agent = f"py-trello/{sys_platform}"
+    
+    return user_agent
 
 
 def create_oauth_token(expiration=None, scope=None, key=None, secret=None, name=None, output=True):


### PR DESCRIPTION
This adds an HTTP User-Agent to all of the requests made by the client.

Recently, there was an issue where Trello put `api.trello.com` behind CloudFront, which caused `GET` requests with an empty body to return a 403 status code (see: https://github.com/sarumont/py-trello/issues/373).

A fix for fixing GET requests with a body is already pending (see: https://github.com/sarumont/py-trello/pull/374).

For future possible issues, adding a User-Agent to this library will help Trello SREs identify where affected traffic is coming from, which means a better experience for users!