### PR TITLE
Add support for boards limit in search call

### DIFF
--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -310,7 +310,7 @@ class TrelloClient(object):
             raise Exception("Webhook creating failed: %s" % response.text)
 
     def search(self, query, partial_match=False, models=[],
-               board_ids=[], org_ids=[], card_ids=[], cards_limit=10):
+               board_ids=[], org_ids=[], card_ids=[], cards_limit=10, boards_limit=10):
         """
         Search trello given a query string.
 
@@ -350,6 +350,8 @@ class TrelloClient(object):
         if card_ids:
             query_params['idCards'] = card_ids
         query_params['cards_limit'] = cards_limit
+        query_params['boards_limit'] = cards_limit
+
 
         # Request result fields required to instantiate class objects
         query_params['board_fields'] = ['name,url,desc,closed']

--- a/trello/trelloclient.py
+++ b/trello/trelloclient.py
@@ -350,7 +350,7 @@ class TrelloClient(object):
         if card_ids:
             query_params['idCards'] = card_ids
         query_params['cards_limit'] = cards_limit
-        query_params['boards_limit'] = cards_limit
+        query_params['boards_limit'] = boards_limit
 
 
         # Request result fields required to instantiate class objects


### PR DESCRIPTION
Trello has added support for `boards_limit` when using the search API. This PR adds that parameter to the method call.

See: [https://developer.atlassian.com/cloud/trello/rest/api-group-search/#api-search-get](https://developer.atlassian.com/cloud/trello/rest/api-group-search/#api-search-get)